### PR TITLE
Update upstream and jessie reprod

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Processing triggers for libc-bin (2.24-8) ...
 $ debuerreotype-gen-sources-list rootfs stretch http://deb.debian.org/debian http://security.debian.org/debian-security
 
 $ debuerreotype-tar rootfs - | sha256sum
-799e1d60e516d6ba41a17a6cfe7c26c0e5749721efe18f30618e799f41c9cd65  -
+745b94242ba9427bd0991b2fadb23e328170e7e59d441c08dde971eef257767a  -
 
 $ # try it!  you should get that same sha256sum value!
 ```

--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-0.7-dev-mullvad
+0.9-dev-mullvad

--- a/scripts/.tar-exclude
+++ b/scripts/.tar-exclude
@@ -6,6 +6,10 @@
 ./proc/**
 ./sys/**
 
+# Clean up fontconfig
+./var/cache/fontconfig/**
+
+
 ./var/cache/apt/**
 ./var/lib/apt/lists/**
 

--- a/scripts/debuerreotype-chroot
+++ b/scripts/debuerreotype-chroot
@@ -31,5 +31,6 @@ unshare --mount bash -Eeuo pipefail -c '
 			mount --rbind "/$dir" "$targetDir/$dir"
 		fi
 	done
+	mount --rbind --read-only /etc/resolv.conf "$targetDir/etc/resolv.conf"
 	exec chroot "$targetDir" /usr/bin/env -i PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" TZ="$TZ" LC_ALL="$LC_ALL" SOURCE_DATE_EPOCH="$epoch" "$@"
 ' -- "$cmd" "$@"

--- a/scripts/debuerreotype-gen-sources-list
+++ b/scripts/debuerreotype-gen-sources-list
@@ -54,10 +54,11 @@ deb() {
 			;;
 
 		*)
+			# https://salsa.debian.org/installer-team/apt-setup/tree/d7a642fb5fc76e4f0b684db53984bdb9123f8360/generators
+			deb "$mirror" "$suite" "$comp"            # "50mirror"
+			deb "$secmirror" "$suite/updates" "$comp" # "91security"
+			deb "$mirror" "$suite-updates" "$comp"    # "92updates"
 			# https://wiki.debian.org/SourcesList#Example_sources.list
-			deb "$mirror" "$suite" "$comp"
-			deb "$mirror" "$suite-updates" "$comp"
-			deb "$secmirror" "$suite/updates" "$comp"
 			;;
 	esac
 } > "$targetDir/etc/apt/sources.list"

--- a/scripts/debuerreotype-init
+++ b/scripts/debuerreotype-init
@@ -157,8 +157,9 @@ echo "$epoch" \
 	| cut -f1 -d' ' \
 	> "$targetDir/etc/machine-id" # TODO should we only do this if "/etc/machine-id" already exists?
 {
-	echo 'nameserver 8.8.8.8'
-	echo 'nameserver 8.8.4.4'
+	echo '# https://1.1.1.1 (privacy-focused, highly-available DNS service)'
+	echo 'nameserver 1.1.1.1'
+	echo 'nameserver 1.0.0.1'
 } > "$targetDir/etc/resolv.conf"
 chmod 0644 \
 	"$targetDir/etc/hostname" \

--- a/scripts/debuerreotype-minimizing-config
+++ b/scripts/debuerreotype-minimizing-config
@@ -118,13 +118,20 @@ case "$aptVersion" in
 
 			Acquire::GzipIndexes "true";
 		EOF
-		if [[ "$aptVersion" == 0.* ]] || "$thisDir/debuerreotype-chroot" "$targetDir" dpkg --compare-versions "$aptVersion" '<<' '1.0.9.2~'; then
+		# https://github.com/debuerreotype/debuerreotype/issues/41
+		isDebianJessie="$([ -f "$targetDir/etc/os-release" ] && source "$targetDir/etc/os-release" && [ "${ID:-}" = 'debian' ] && [ "${VERSION_ID:-}" = '8' ] && echo '1')" || :
+		if [ -n "$isDebianJessie" ] || [[ "$aptVersion" == 0.* ]] || "$thisDir/debuerreotype-chroot" "$targetDir" dpkg --compare-versions "$aptVersion" '<<' '1.0.9.2~'; then
 			cat >> "$targetDir/etc/apt/apt.conf.d/docker-gzip-indexes" <<-'EOF'
 
 				# https://salsa.debian.org/apt-team/apt/commit/b0f4b486e6850c5f98520ccf19da71d0ed748ae4; released in src:apt 1.0.9.2, 2014-10-02
 				# prior to src:apt 1.0.9.2, "Acquire::GzipIndexes" _only_ applied to gzip-compressed list files, so we need to prefer those on older releases
 				Acquire::CompressionTypes::Order:: "gz";
 			EOF
+			if [ -n "$isDebianJessie" ]; then
+				cat >> "$targetDir/etc/apt/apt.conf.d/docker-gzip-indexes" <<-'EOF'
+					# see also https://github.com/debuerreotype/debuerreotype/issues/41 (details of a bug that's apparently specific to Debian Jessie)
+				EOF
+			fi
 		fi
 		chmod 0644 "$targetDir/etc/apt/apt.conf.d/docker-gzip-indexes"
 


### PR DESCRIPTION
Adds upstream changes and additionally removes /var/cache/fontconfig to make builds of debian jessie reproducible.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/debuerreotype/3)
<!-- Reviewable:end -->
